### PR TITLE
Signal improvements

### DIFF
--- a/src/mini-signals.js
+++ b/src/mini-signals.js
@@ -24,6 +24,10 @@ export class MiniSignalBinding {
     return true;
   }
 
+  execute (...arguments) {
+    this._fn.apply(node._thisArg, arguments);
+  }
+  
 }
 
 /**

--- a/src/mini-signals.js
+++ b/src/mini-signals.js
@@ -15,6 +15,7 @@ export class MiniSignalBinding {
     this._once = once;
     this._thisArg = thisArg;
     this._next = this._prev = this._owner = null;
+    this.active = true;
   }
 
   detach () {
@@ -58,6 +59,7 @@ export class MiniSignal {
   */
   constructor () {
     this._head = this._tail = undefined;
+    this.active = true;
   }
 
   /**
@@ -107,8 +109,10 @@ export class MiniSignal {
     let node = this._head;
 
     if (!node) return false;
-
+    if (!this.active) return false;
+    
     while (node) {
+      if (!node.active) continue;
       if (node._once) this.detach(node);
       node._fn.apply(node._thisArg, arguments);
       node = node._next;


### PR DESCRIPTION
These edits adds the js-signals `.active` functionality to mini-signals by adding an `active` property to the `MiniSignal` and `MiniSignalBinding` classes, which solves this issue https://github.com/Hypercubed/mini-signals/issues/9.

Also adding another improvement to the library which is the `execute` function which is a variadic function, instead of expecting an array of arguments as implemented in js-signals.